### PR TITLE
Analytics: Send node.id as eventLabel

### DIFF
--- a/src/django-bulbs-public/templates/clickventure/partials/link/action.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/action.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-action"
     data-track-action="Next Page"
-    data-track-label="#">
+    data-track-label="{{ node.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/action_finish.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/action_finish.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-action"
     data-track-action="Checkpoint"
-    data-track-label="#">
+    data-track-label="{{ node.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/dialogue.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/dialogue.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-word-bubble"
     data-track-action="Next Page"
-    data-track-label="#">
+    data-track-label="{{ node.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/music.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/music.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-music"
     data-track-action="Next Page"
-    data-track-label="#">
+    data-track-label="{{ node.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/quiz.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/quiz.html
@@ -1,7 +1,7 @@
 <div
     class="clickventure-node-link-button clickventure-node-link-quiz"
     data-track-action="Next Page"
-    data-track-label="#">
+    data-track-label="{{ node.id }}">
   <input
       id="input-{{ node.id }}-{{ link.to_node }}-{{ action_index }}"
       name="clickventure_quiz[{{ node.id }}][{{ link.to_node }}]"

--- a/src/django-bulbs-public/templates/clickventure/partials/link/restart.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/restart.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-finish-links-restart"
     data-track-action="Start Over"
-    data-track-label="#">
+    data-track-label="{{ node.id }}">
   <span class="clickventure-node-link-text">Start Over</span>
 </button>


### PR DESCRIPTION
For Kinja migration Clickventure tracking.

[Asana Task](https://app.asana.com/0/464944410244520/627545553224573)


view-source, and search for data-track-label: http://embed-analytics-fixes.test.clickhole.com/clickventure/embed/1828#1