### PR TITLE
Tracking: Use NEXT/TARGET node instead of CURRENT node for eventLabel

### DIFF
--- a/src/django-bulbs-public/templates/clickventure/partials/link/action.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/action.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-action"
     data-track-action="Next Page"
-    data-track-label="{{ link.id }}">
+    data-track-label="{{ link.to_node.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/action.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/action.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-action"
     data-track-action="Next Page"
-    data-track-label="{{ link.to_node.id }}">
+    data-track-label="{{ link.to_node }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/action.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/action.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-action"
     data-track-action="Next Page"
-    data-track-label="{{ node.id }}">
+    data-track-label="{{ link.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/action_finish.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/action_finish.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-action"
     data-track-action="Checkpoint"
-    data-track-label="{{ link.to_node.id }}">
+    data-track-label="{{ link.to_node }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/action_finish.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/action_finish.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-action"
     data-track-action="Checkpoint"
-    data-track-label="{{ link.id }}">
+    data-track-label="{{ link.to_node.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/action_finish.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/action_finish.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-action"
     data-track-action="Checkpoint"
-    data-track-label="{{ node.id }}">
+    data-track-label="{{ link.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/dialogue.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/dialogue.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-word-bubble"
     data-track-action="Next Page"
-    data-track-label="{{ link.id }}">
+    data-track-label="{{ link.to_node.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/dialogue.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/dialogue.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-word-bubble"
     data-track-action="Next Page"
-    data-track-label="{{ node.id }}">
+    data-track-label="{{ link.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/dialogue.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/dialogue.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-word-bubble"
     data-track-action="Next Page"
-    data-track-label="{{ link.to_node.id }}">
+    data-track-label="{{ link.to_node }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/music.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/music.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-music"
     data-track-action="Next Page"
-    data-track-label="{{ link.to_node.id }}">
+    data-track-label="{{ link.to_node }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/music.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/music.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-music"
     data-track-action="Next Page"
-    data-track-label="{{ link.id }}">
+    data-track-label="{{ link.to_node.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/music.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/music.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-link-button clickventure-node-link-music"
     data-track-action="Next Page"
-    data-track-label="{{ node.id }}">
+    data-track-label="{{ link.id }}">
   <span class="clickventure-node-link-text">{{ link.body|safe }}</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/quiz.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/quiz.html
@@ -1,7 +1,7 @@
 <div
     class="clickventure-node-link-button clickventure-node-link-quiz"
     data-track-action="Next Page"
-    data-track-label="{{ link.id }}">
+    data-track-label="{{ link.to_node.id }}">
   <input
       id="input-{{ node.id }}-{{ link.to_node }}-{{ action_index }}"
       name="clickventure_quiz[{{ node.id }}][{{ link.to_node }}]"

--- a/src/django-bulbs-public/templates/clickventure/partials/link/quiz.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/quiz.html
@@ -1,7 +1,7 @@
 <div
     class="clickventure-node-link-button clickventure-node-link-quiz"
     data-track-action="Next Page"
-    data-track-label="{{ node.id }}">
+    data-track-label="{{ link.id }}">
   <input
       id="input-{{ node.id }}-{{ link.to_node }}-{{ action_index }}"
       name="clickventure_quiz[{{ node.id }}][{{ link.to_node }}]"

--- a/src/django-bulbs-public/templates/clickventure/partials/link/quiz.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/quiz.html
@@ -1,7 +1,7 @@
 <div
     class="clickventure-node-link-button clickventure-node-link-quiz"
     data-track-action="Next Page"
-    data-track-label="{{ link.to_node.id }}">
+    data-track-label="{{ link.to_node }}">
   <input
       id="input-{{ node.id }}-{{ link.to_node }}-{{ action_index }}"
       name="clickventure_quiz[{{ node.id }}][{{ link.to_node }}]"

--- a/src/django-bulbs-public/templates/clickventure/partials/link/restart.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/restart.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-finish-links-restart"
     data-track-action="Start Over"
-    data-track-label="{{ link.id }}">
+    data-track-label="#">
   <span class="clickventure-node-link-text">Start Over</span>
 </button>

--- a/src/django-bulbs-public/templates/clickventure/partials/link/restart.html
+++ b/src/django-bulbs-public/templates/clickventure/partials/link/restart.html
@@ -1,6 +1,6 @@
 <button
     class="clickventure-node-finish-links-restart"
     data-track-action="Start Over"
-    data-track-label="{{ node.id }}">
+    data-track-label="{{ link.id }}">
   <span class="clickventure-node-link-text">Start Over</span>
 </button>


### PR DESCRIPTION
Fixes CV "Next Page" eventLabel event to use TARGET node (instead of CURRENT node).

Also don't need to send any node info for "Start Over" eventLabel (and less confusing if only sending node for "Next Page"). 

Addresses @allisonallisonw feedback https://github.com/theonion/bulbs-component-clickventure/pull/29#issuecomment-380467496